### PR TITLE
A hack of a fix for window systems. Fixes #11

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.locate = function locate(name, root, start) {
     file = path.join(start, name);
     if (fs.existsSync(file)) {
         return {
-            root : file.replace(name, ''),
+            root : file.replace(path.normalize(name), ''),
             file: file,
             ext: path.extname(name).substr(1),
             name: name.replace(path.extname(name), '')

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var fileResolver = require('../index'),
-    test = require('tape');
+    test = require('tape'),
+    path = require('path');
 
 test('fileResolver', function (t) {
     t.test('Creating a file resolver without options should throw assertion error', function (t) {
@@ -16,14 +17,14 @@ test('fileResolver', function (t) {
     });
 
     t.test('Creating a file resolver with options', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures/root', fallback: 'en_US', ext: 'dust'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures/root'), fallback: 'en_US', ext: 'dust'});
         t.deepEqual(resolvr.fallbackLocale, { country: 'US', language: 'en' });
         t.equal(typeof resolvr._locate, 'function');
         t.end();
     });
 
     t.test('Creating a file resolver with options', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures/root', fallback: 'en_US', ext: '.dust'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures/root'), fallback: 'en_US', ext: '.dust'});
         t.deepEqual(resolvr.fallbackLocale, { country: 'US', language: 'en' });
         t.equal(typeof resolvr._locate, 'function');
         t.end();
@@ -31,68 +32,68 @@ test('fileResolver', function (t) {
 
 
     t.test('resolving for an extension with default locale', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures/root', fallback: 'en_US', ext: 'dust'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures/root'), fallback: 'en_US', ext: 'dust'});
         var info = resolvr.resolve('test');
 
-        t.equal(info.root, __dirname + '/fixtures/root/US/en/');
-        t.equal(info.file, __dirname + '/fixtures/root/US/en/test.dust');
+        t.equal(info.root, __dirname + path.normalize('/fixtures/root/US/en/'));
+        t.equal(info.file, __dirname + path.normalize('/fixtures/root/US/en/test.dust'));
         t.equal(info.ext, 'dust');
         t.equal(info.name, 'test');
         t.end();
     });
 
     t.test('resolving for an extension with a specified locale', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures/root', fallback: 'en_US', ext: 'dust'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures/root'), fallback: 'en_US', ext: 'dust'});
         var info = resolvr.resolve('test', 'es_US');
 
-        t.equal(info.root, __dirname + '/fixtures/root/US/es/');
-        t.equal(info.file, __dirname + '/fixtures/root/US/es/test.dust');
+        t.equal(info.root, __dirname + path.normalize('/fixtures/root/US/es/'));
+        t.equal(info.file, __dirname + path.normalize('/fixtures/root/US/es/test.dust'));
         t.equal(info.ext, 'dust');
         t.equal(info.name, 'test');
         t.end();
     });
 
     t.test('Resolve a bundle not in the primary langauge but is in the fallback', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures/root', fallback: 'en_US', ext: 'dust'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures/root'), fallback: 'en_US', ext: 'dust'});
         var info = resolvr.resolve('fallback', 'es_US');
 
-        t.equal(info.root, __dirname + '/fixtures/root/US/en/');
-        t.equal(info.file, __dirname + '/fixtures/root/US/en/fallback.dust');
+        t.equal(info.root, __dirname + path.normalize('/fixtures/root/US/en/'));
+        t.equal(info.file, __dirname + path.normalize('/fixtures/root/US/en/fallback.dust'));
         t.equal(info.ext, 'dust');
         t.equal(info.name, 'fallback');
         t.end();
     });
 
     t.test('Creating a file resolver with options', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures/root', ext: 'dust'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures/root'), ext: 'dust'});
         t.deepEqual(resolvr.fallbackLocale, { country: '', language: '' });
         t.equal(typeof resolvr._locate, 'function');
         t.end();
     });
 
     t.test('resolving for an extension without locale', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures/root', ext: 'dust'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures/root'), ext: 'dust'});
         var info = resolvr.resolve('test');
 
-        t.equal(info.root, __dirname + '/fixtures/root/');
-        t.equal(info.file, __dirname + '/fixtures/root/test.dust');
+        t.equal(info.root, __dirname + path.normalize('/fixtures/root/'));
+        t.equal(info.file, __dirname + path.normalize('/fixtures/root/test.dust'));
         t.equal(info.ext, 'dust');
         t.equal(info.name, 'test');
         t.end();
     });
 
     t.test('trying to resolve with a locale object', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures/root', ext: 'dust'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures/root'), ext: 'dust'});
         var info = resolvr.resolve('test', { country: 'US', language: 'es' });
-        t.equal(info.root, __dirname + '/fixtures/root/US/es/');
-        t.equal(info.file, __dirname + '/fixtures/root/US/es/test.dust');
+        t.equal(info.root, __dirname + path.normalize('/fixtures/root/US/es/'));
+        t.equal(info.file, __dirname + path.normalize('/fixtures/root/US/es/test.dust'));
         t.equal(info.ext, 'dust');
         t.equal(info.name, 'test');
         t.end();
     });
 
     t.test('Creating a file resolver with invalid root', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures', ext: 'dust'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures'), ext: 'dust'});
         t.deepEqual(resolvr.fallbackLocale, { country: '', language: '' });
         t.equal(typeof resolvr._locate, 'function');
         var info = resolvr.resolve('test');
@@ -104,7 +105,7 @@ test('fileResolver', function (t) {
     });
 
     t.test('Creating a file resolver with invalid locale', function (t) {
-        var resolvr = fileResolver.create({root: __dirname + '/fixtures/root', ext: 'dust', fallback: 'es'});
+        var resolvr = fileResolver.create({root: __dirname + path.normalize('/fixtures/root'), ext: 'dust', fallback: 'es'});
         t.deepEqual(resolvr.fallbackLocale, { country: '', language: 'es' });
         t.equal(typeof resolvr._locate, 'function');
         t.end();


### PR DESCRIPTION
Hey you PayPal peeps! Long time no see. :smile: 

Sadly, my first non-private contribution to kraken is an ugly one, but this issue should affect every Windows user out there that uses folders for template organization.

The tests change is even uglier than the code change, but I couldn't stomach submitting a PR without the tests passing. They blew up horribly on windows.

Thanks @mmadaria for providing a fix. I'm simply implementing it and making tests pass.

I hope there's a better fix out there, but I'd settle for not having a modified module in my node_modules directory.

--Bryan